### PR TITLE
add state type for custom serialization

### DIFF
--- a/serialization.go
+++ b/serialization.go
@@ -3,10 +3,24 @@ package kll
 import (
 	"bytes"
 	"encoding/gob"
+	"unsafe"
 )
 
-type serializable struct {
-	Compactors []compactor
+// we know that compactor is really a []float64, and we want to refer to them
+// in the state, so we can just unsafely convert them.
+
+func compactorsAsFloats(c []compactor) [][]float64 {
+	return *(*[][]float64)(unsafe.Pointer(&c))
+}
+
+func floatsAsCompactors(f [][]float64) []compactor {
+	return *(*[]compactor)(unsafe.Pointer(&f))
+}
+
+// State represents the state of the Sketch. It is used for serializing and
+// deserializing to disk.
+type State struct {
+	Compactors [][]float64
 	K          int
 	H          int
 	Size       int
@@ -14,17 +28,33 @@ type serializable struct {
 	Count      int
 }
 
+// State returns the current state of the Sketch. The state is invalid if any
+// other methods of the Sketch are called, and it must not be mutated.
+func (s *Sketch) State() State {
+	return State{
+		Compactors: compactorsAsFloats(s.compactors),
+		K:          s.k,
+		H:          s.H,
+		Size:       s.size,
+		MaxSize:    s.maxSize,
+	}
+}
+
+// SetState sets the state of the Sketch to the passed State. The memory is
+// shared, so the passed State is invalid to be read from or written to after
+// this call.
+func (s *Sketch) SetState(state State) {
+	s.compactors = floatsAsCompactors(state.Compactors)
+	s.k = state.K
+	s.H = state.H
+	s.size = state.Size
+	s.maxSize = state.MaxSize
+}
+
 // MarshalBinary implements encoding.BinaryMarshaler.
 func (s *Sketch) MarshalBinary() ([]byte, error) {
 	var buf bytes.Buffer
-	err := gob.NewEncoder(&buf).Encode(
-		serializable{
-			Compactors: s.compactors,
-			K:          s.k,
-			H:          s.H,
-			Size:       s.size,
-			MaxSize:    s.maxSize,
-		})
+	err := gob.NewEncoder(&buf).Encode(s.State())
 	if err != nil {
 		return nil, err
 	}
@@ -33,15 +63,11 @@ func (s *Sketch) MarshalBinary() ([]byte, error) {
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
 func (s *Sketch) UnmarshalBinary(data []byte) error {
-	var r serializable
+	var r State
 	err := gob.NewDecoder(bytes.NewReader(data)).Decode(&r)
 	if err != nil {
 		return err
 	}
-	s.compactors = r.Compactors
-	s.k = r.K
-	s.H = r.H
-	s.size = r.Size
-	s.maxSize = r.MaxSize
+	s.SetState(r)
 	return nil
 }

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -1,0 +1,23 @@
+package kll
+
+import (
+	"math/rand"
+	"testing"
+)
+
+var stateBlackhole State
+
+func BenchmarkGetState(b *testing.B) {
+	const k = 1000
+	r := New(k)
+	for i := 0; i < 100*k; i++ {
+		r.Update(rand.NormFloat64())
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		stateBlackhole = r.State()
+	}
+}


### PR DESCRIPTION
this lets people write their own serializers. it uses unsafe which might limit the applicability though. that's the tradeoff against copying the slice of slices or removing the compactor type.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgryski/go-kll/4)

<!-- Reviewable:end -->
